### PR TITLE
Add PID_FILE_SOCAT_EXTRA and minor README/echo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A typical installation will include either GPG4WIN (`--install-gpg4win`) or GnuP
 For example:
 
 ```
-./yubi-to-wsl --install-target /mnt/c/yubi2wsl
+./yubi-to-wsl.sh --install-target /mnt/c/yubi2wsl
 ```
 
 Once installed and running, plug in your YubiKey and verify operation of SSH with:

--- a/yubi-to-wsl.sh
+++ b/yubi-to-wsl.sh
@@ -48,6 +48,7 @@ GPG_AGENT_EXTRA_SOCK_FILE=$HOME/.gnupg/S.gpg-agent.extra
 GPG_AGENT_EXTRA_SOCK_FILE_WIN=C:/Users/$USERNAME/AppData/Roaming/gnupg/S.gpg-agent.extra
 PID_FILE_PAGEANT=pageant.pid
 PID_FILE_SOCAT=socat.pid
+PID_FILE_SOCAT_EXTRA=socat_extra.pid
 
 
 EXE_GPGCONF="/mnt/c/Program Files (x86)/GnuPG/bin/gpgconf.exe"

--- a/yubi-to-wsl.sh
+++ b/yubi-to-wsl.sh
@@ -337,6 +337,6 @@ echo "Creating: $INSTALL_TARGET/$SH_STOP"
 echo "$STOP_FILE" > $INSTALL_TARGET/$SH_STOP
 
 success "\nInstall Done!"
-echo "Now add the following to your ~/bashrc:"
+echo "Now add the following to your ~/.bashrc:"
 echo "$INSTALL_TARGET/$SH_START"
 cat "$INSTALL_TARGET/$SH_ENV"


### PR DESCRIPTION
Thanks so much for creating this @Gadgetoid its made the process of getting access to the Yubikey in WSL so much clearer.

I've made some minor changes to get it working locally.

* Initialises the `PID_FILE_SOCAT_EXTRA` variable with a `socat_extra.pid`
* Minor tweak to the README
* Minor tweak to the post-install message to reference the `~/.bashrc` rather than `~/bashrc`